### PR TITLE
Fix test assertion in example.spec.ts for 'get started link' test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -14,5 +14,5 @@ test('get started link', async ({ page }) => {
   await page.getByRole('link', { name: 'Get started' }).click();
 
   // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).not.toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
 });


### PR DESCRIPTION
## Description

This PR fixes the failing test assertion in the "get started link" test.

## Problem

The test was incorrectly expecting the "Installation" heading to **not** be visible after clicking the "Get started" link on the Playwright homepage. However, clicking that link navigates to the Installation page where the heading should be visible.

## Solution

- Removed `.not` from the assertion on line 14
- Changed from `not.toBeVisible()` to `toBeVisible()`
- The test now correctly expects the Installation heading to be visible

## Changes

```diff
- await expect(page.getByRole('heading', { name: 'Installation' })).not.toBeVisible();
+ await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
```

## Testing

After this fix, the test should pass correctly as it will properly verify that:
1. The "Get started" link is clicked
2. The page navigates to the Installation documentation
3. The "Installation" heading is visible on the page

Fixes #1